### PR TITLE
Unified glob usage across copy/delete - for better directory support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ Optionally pass `replacer` and `space` as the last two arguments, as defined by 
 
 Default value for `space` is `2`, when not specified.
 
-### `#delete(filepath)`
+### `#delete(filepath, [options])`
 
 Delete a file or a directory.
+
+`filePath` can also be a `glob`. If `filePath` is glob, you can optionally pass in an `options.globOptions` object to change its pattern matching behavior. The full list of options are being described [here](https://github.com/isaacs/node-glob#options). The `sync` flag is forced to be `true` in `globOptions`.
 
 ### `#copy(from, to, [options])`
 
@@ -50,7 +52,7 @@ Copy a file from the `from` path to the `to` path.
 
 Optionally, pass an `options.process` function (`process(contents)`) returning a string or a buffer who'll become the new file content. The process function will take a single contents argument who is the copied file contents as a `Buffer`.
 
-`from` can be a glob pattern that'll be match against the file system. If that's the case, then `to` must be an output directory.
+`from` can be a glob pattern that'll be match against the file system. If that's the case, then `to` must be an output directory. For a globified `from`, you can optionally pass in an `options.globOptions` object to change its pattern matching behavior. The full list of options are being described [here](https://github.com/isaacs/node-glob#options). The `nodir` flag is forced to be `true` in `globOptions` to ensure a vinyl object representing each matching directory is marked as `deleted` in the `mem-fs` store.
 
 ### `#copyTpl(from, to, context, [settings])`
 

--- a/actions/commit.js
+++ b/actions/commit.js
@@ -8,7 +8,10 @@ var mkdirp = require('mkdirp');
 var rimraf = require('rimraf');
 
 function write(file) {
-  mkdirp.sync(path.dirname(file.path));
+  var dir = path.dirname(file.path);
+  if (!fs.existsSync(dir)) {
+    mkdirp.sync(dir);
+  }
   fs.writeFileSync(file.path, file.contents, {
     mode: file.stat ? file.stat.mode : null
   });

--- a/actions/delete.js
+++ b/actions/delete.js
@@ -1,19 +1,31 @@
 'use strict';
 
 var assert = require('assert');
+var _ = require('lodash');
+var glob = require('glob');
+var util = require('../util/util');
 
-function deleteFile(file, store) {
+function deleteFile(path, store) {
+  var file = store.get(path);
   file.state = 'deleted';
   file.contents = new Buffer('');
   store.add(file);
 }
 
-module.exports = function (path) {
-  var deletedPath = this.store.get(path).path;
+module.exports = function (path, options) {
+  path = util.globify(path);
+  options = options || { globOptions : {} };
+
+  var globOptions = _.extend(options.globOptions, { sync: true });
+  var g = new glob.Glob(path, globOptions);
+  var files = g.found;
+  files.forEach(function (file) {
+    deleteFile(file, this.store)
+  }.bind(this));
 
   this.store.each(function (file) {
-    if (file.path.indexOf(deletedPath) === 0) {
-      deleteFile(file, this.store);
+    if (g.minimatch.match(file.path)) {
+      deleteFile(file.path, this.store);
     }
   }.bind(this));
 };

--- a/test/copy.js
+++ b/test/copy.js
@@ -37,15 +37,27 @@ describe('#copy()', function () {
     assert.equal(this.fs.read(newPath), contents);
   });
 
+  it('copy by directory', function () {
+    this.fs.copy(__dirname + '/fixtures', '/output');
+    assert.equal(this.fs.read('/output/file-a.txt'), 'foo\n');
+    assert.equal(this.fs.read('/output/nested/file.txt'), 'nested\n');
+  });
+
   it('copy by globbing', function () {
     this.fs.copy(__dirname + '/fixtures/**', '/output');
     assert.equal(this.fs.read('/output/file-a.txt'), 'foo\n');
     assert.equal(this.fs.read('/output/nested/file.txt'), 'nested\n');
   });
 
+  it('accepts directory name with "."', function () {
+    this.fs.copy(__dirname + '/fixtures/**', '/out.put');
+    assert.equal(this.fs.read('/out.put/file-a.txt'), 'foo\n');
+    assert.equal(this.fs.read('/out.put/nested/file.txt'), 'nested\n');
+  });
+
   it('requires destination directory when globbing', function () {
     assert.throws(
-      this.fs.copy.bind(this.fs, __dirname + '/fixtures/**', '/output/file.a')
+      this.fs.copy.bind(this.fs, __dirname + '/fixtures/**', __dirname + '/fixtures/file-a.txt')
     );
   });
 

--- a/test/delete.js
+++ b/test/delete.js
@@ -21,7 +21,6 @@ describe('#delete()', function () {
   it('delete a directory', function () {
     var dirpath = path.join(__dirname, 'fixtures/nested');
     var nestedFile = path.join(dirpath, 'file.txt');
-    this.fs.read(nestedFile)
     this.fs.delete(dirpath);
     assert.equal(this.fs.store.get(dirpath).state, 'deleted');
     assert.equal(this.fs.store.get(nestedFile).state, 'deleted');

--- a/test/util.js
+++ b/test/util.js
@@ -1,27 +1,55 @@
 'use strict';
 
+var path = require('path');
 var assert = require('assert');
 var util = require('../util/util');
 
 describe('util.getCommonPath()', function () {
-  it('find the common root of files in same directory', function () {
-    assert.equal(
-      util.getCommonPath(['/a/b/c.js', '/a/b/d.js', '/a/b/e.js']),
-      '/a/b'
-    );
+  it('find the common root of /a/b/c, where /a/b/c is an existing directory', function () {
+    var filePath = path.resolve(__dirname, 'fixtures');
+    assert.equal(util.getCommonPath(filePath), filePath);
   });
 
-  it('find the common root of files in differents directory', function () {
-    assert.equal(
-      util.getCommonPath(['/a/b/c.js', '/a/c/d.js', '/a/b/e.js']),
-      '/a'
-    );
+  it('find the common root of /a/b/c, where /a/b/c is an existing file', function () {
+    var filePath = path.resolve(__dirname, 'fixtures');
+    assert.equal(util.getCommonPath(path.join(filePath, 'file-a.txt')), filePath);
   });
 
-  it('find the common root of files sharing no common root', function () {
-    assert.equal(
-      util.getCommonPath(['/a/b/c.js', '/b/d.js', '/c/e.js']),
-      '/'
-    );
+  it('find the common root of glob /a/b/**', function () {
+    assert.equal(util.getCommonPath('/a/b/**'), '/a/b');
+  });
+
+  it('find the common root of glob /a/b*/c', function () {
+    assert.equal(util.getCommonPath('/a/b*/c'), '/a');
+  });
+
+  it('find the common root of glob /a/b/*.ext', function () {
+    assert.equal(util.getCommonPath('/a/b/*.ext'), '/a/b');
+  });
+});
+
+
+describe('util.globify()', function () {
+  it('returns path for file path', function () {
+    var filePath = path.resolve(__dirname, 'fixtures/file-a.txt');
+    assert.equal(util.globify(filePath), filePath);
+  });
+
+  it('returns path for nonexisting path', function () {
+    var filePath = '/nonexisting.file';
+    assert.equal(util.globify(filePath), filePath);
+  });
+
+  it('returns glob for glob path', function () {
+    var filePath = path.resolve(__dirname, 'fixtures/*.txt');
+    assert.equal(util.globify(filePath), filePath);
+
+    var filePath2 = path.resolve(__dirname, 'fixtures/file-{a,b}.txt');
+    assert.equal(util.globify(filePath2), filePath2);
+  });
+
+  it('returns globified path for directory path', function () {
+    var filePath = path.resolve(__dirname, 'fixtures/nested');
+    assert.equal(util.globify(filePath), path.join(filePath, '**'));
   });
 });

--- a/util/util.js
+++ b/util/util.js
@@ -1,20 +1,31 @@
 'use strict';
 
+var fs = require('fs');
 var path = require('path');
+var glob = require('glob');
 
-exports.getCommonPath = function (files) {
-  var dirs = files.map(path.dirname);
-  var root = dirs.reduce(function (prev, current) {
-    var keep = [];
-    prev = prev.split('/');
-    current = current.split('/');
-    prev.forEach(function (part, index) {
-      if (part === current[index]) {
-        keep.push(part);
-      }
-    });
-    return keep.join('/');
-  }, dirs[0]);
+exports.getCommonPath = function (filePath) {
+  filePath = this.globify(filePath);
+  var globStartIndex = filePath.indexOf('*');
+  if (globStartIndex !== -1) {
+    filePath = filePath.substring(0, globStartIndex + 1);
+  }
 
-  return root || '/';
+  return path.dirname(filePath);
+};
+
+
+exports.globify = function (filePath) {
+  if (glob.hasMagic(filePath) || !fs.existsSync(filePath)) {
+    return filePath;
+  }
+
+  var fsStats = fs.statSync(filePath);
+  if (fsStats.isFile()) {
+    return filePath;
+  } else if (fsStats.isDirectory()) {
+    return path.join(filePath, '**');
+  } else {
+    throw new Error('Only file path or directory path are supported.');
+  }
 };


### PR DESCRIPTION
@SBoudrias This PR contains breaking change!

This PR attempts to address a list of issues I found around copy/delete.

* #15
* Currently, `fs.delete` only deletes files that is buffered in `mem-fs` store. It seems like [this is intentional](https://github.com/SBoudrias/mem-fs-editor/blob/master/test/delete.js#L24), but I found this a little cumbersome in many Yeoman generator use cases. So the new implementation will delete both uncommitted files in store, as well as physical files that has not been read into the store. **This is a breaking change**
* Currently, `copy` only support `from` to be either a file, or a glob pattern that uses `*`. But [not all glob patterns use `*`](https://github.com/isaacs/node-glob#globhasmagicpattern-options). The new implementation supports `from` to be the following:
  1. a path that map to an existing file
  2. a path that map to an existing directory, in which case, `from` is converted to a glob pattern `form + '/**`
  3. a glob pattern, user can also optionally pass in a `options.globOptions` object to customize the glob pattern matching behavior
* Currently, `delete` does not support glob pattern. The new implementation make this possible. And `options.globOptions` is also made available here.
* When calling `copy` with `from` being a glob pattern, and `to` being `/a/b/c.is.a.dir/` will throw exception. Some directory does contain `.` in its name.
* Currently, calling `copy` with `from = '/foo/a/**'` and `to = '/bar'`, and if the only file under `/foo/a/` is `/foo/a/b/c.txt` then what's end up in `/bar` would be, `/bar/c.txt`. But later if we create one more file under `/foo/a/` (e.g. `/foo/a/d/e.txt`), and rerun the Yeoman generator again, the program will try copy these files into `/bar/b/c.txt` and `/bar/d/e/txt`. This behavior may not meet the average expectation.