### PR TITLE
Adds support for multiple glob patterns.

### DIFF
--- a/actions/copy.js
+++ b/actions/copy.js
@@ -4,6 +4,7 @@ var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
 var glob = require('glob');
+var globby = require('globby');
 var _ = require('lodash');
 var File = require('vinyl');
 var util = require('../util/util');
@@ -18,7 +19,7 @@ exports.copy = function(from, to, options) {
   to = path.resolve(to);
   options = options || {};
 
-  if (!glob.hasMagic(from)) {
+  if (!Array.isArray(from) && !glob.hasMagic(from)) {
     return this._copySingle(from, to, options);
   }
 
@@ -28,8 +29,8 @@ exports.copy = function(from, to, options) {
   );
 
   var globOptions = _.extend(options.globOptions || {}, { nodir: true });
-  var files = glob.sync(from, globOptions);
-  var root = util.getCommonPath(from);
+  var files = globby.sync(from, globOptions);
+  var root = util.getCommonPath(Array.isArray(from) ? files : from);
 
   files.forEach(function (file) {
     var toFile = path.relative(root, file);

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "index.js"
   ],
   "dependencies": {
+    "commondir": "^1.0.1",
     "ejs": "^2.3.1",
     "glob": "^5.0.3",
+    "globby": "^2.0.0",
     "lodash": "^3.6.0",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.2.8",

--- a/test/copy.js
+++ b/test/copy.js
@@ -56,6 +56,13 @@ describe('#copy()', function () {
     assert.equal(this.fs.read('/output/nested/file.txt'), 'nested\n');
   });
 
+  it('copy by globbing multiple patterns', function () {
+    this.fs.copy([__dirname + '/fixtures/**', '!**/*tpl*'], '/output');
+    assert.equal(this.fs.read('/output/file-a.txt'), 'foo\n');
+    assert.equal(this.fs.read('/output/nested/file.txt'), 'nested\n');
+    assert.throws(this.fs.read.bind(this.fs, '/output/file-tpl.txt'));
+  });
+
   it('copy files by globbing and process contents', function () {
     var process = sinon.stub().returnsArg(0);
     this.fs.copy(__dirname + '/fixtures/**', '/output', { process: process });

--- a/util/util.js
+++ b/util/util.js
@@ -3,8 +3,13 @@
 var fs = require('fs');
 var path = require('path');
 var glob = require('glob');
+var commondir = require('commondir');
 
-exports.getCommonPath = function (filePath) {
+exports.getCommonPath = function getCommonPath(filePath) {
+  if (Array.isArray(filePath)) {
+    return commondir(filePath);
+  }
+
   filePath = this.globify(filePath);
   var globStartIndex = filePath.indexOf('*');
   if (globStartIndex !== -1) {
@@ -16,7 +21,7 @@ exports.getCommonPath = function (filePath) {
 
 
 exports.globify = function (filePath) {
-  if (glob.hasMagic(filePath) || !fs.existsSync(filePath)) {
+  if (Array.isArray(filePath) || glob.hasMagic(filePath) || !fs.existsSync(filePath)) {
     return filePath;
   }
 


### PR DESCRIPTION
Uses `globby` to implement support for an array of glob patterns, including exclusions. Useful when conditionally excluding files from being added without affecting files already added by other copy calls:

```js
var scriptFiles = ['src/**/*.js'];

if (options.noTest) {
    scriptFiles.push('!src/**/*.spec.js');
}

this.fs.copy(scriptFiles, ...);
```