### PR TITLE
Added support for arrays of paths and globs.

### DIFF
--- a/actions/copy.js
+++ b/actions/copy.js
@@ -4,6 +4,7 @@ var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
 var glob = require('glob');
+var globby = require('globby');
 var _ = require('lodash');
 var File = require('vinyl');
 var util = require('../util/util');
@@ -18,7 +19,7 @@ exports.copy = function(from, to, options) {
   to = path.resolve(to);
   options = options || {};
 
-  if (!glob.hasMagic(from)) {
+  if (!Array.isArray(from) && !glob.hasMagic(from)) {
     return this._copySingle(from, to, options);
   }
 
@@ -28,7 +29,7 @@ exports.copy = function(from, to, options) {
   );
 
   var globOptions = _.extend(options.globOptions || {}, { nodir: true });
-  var files = glob.sync(from, globOptions);
+  var files = globby.sync(from, globOptions);
   var root = util.getCommonPath(from);
 
   files.forEach(function (file) {

--- a/actions/delete.js
+++ b/actions/delete.js
@@ -2,7 +2,8 @@
 
 var assert = require('assert');
 var _ = require('lodash');
-var glob = require('glob');
+var globby = require('globby');
+var multimatch = require('multimatch');
 var util = require('../util/util');
 
 function deleteFile(path, store) {
@@ -12,19 +13,18 @@ function deleteFile(path, store) {
   store.add(file);
 }
 
-module.exports = function (path, options) {
-  path = util.globify(path);
-  options = options || { globOptions : {} };
+module.exports = function (paths, options) {
+  paths = util.globify(paths);
+  options = options || {};
 
-  var globOptions = _.extend(options.globOptions, { sync: true });
-  var g = new glob.Glob(path, globOptions);
-  var files = g.found;
+  var globOptions = options.globOptions || {};
+  var files = globby.sync(paths, globOptions);
   files.forEach(function (file) {
     deleteFile(file, this.store);
   }.bind(this));
 
   this.store.each(function (file) {
-    if (g.minimatch.match(file.path)) {
+    if (multimatch(paths, file.path).length !== 0) {
       deleteFile(file.path, this.store);
     }
   }.bind(this));

--- a/package.json
+++ b/package.json
@@ -14,10 +14,13 @@
     "index.js"
   ],
   "dependencies": {
+    "commondir": "^1.0.1",
     "ejs": "^2.3.1",
     "glob": "^5.0.3",
+    "globby": "^2.0.0",
     "lodash": "^3.6.0",
     "mkdirp": "^0.5.0",
+    "multimatch": "^2.0.0",
     "rimraf": "^2.2.8",
     "sinon": "^1.12.2",
     "through2": "^0.6.3",

--- a/test/copy.js
+++ b/test/copy.js
@@ -56,6 +56,13 @@ describe('#copy()', function () {
     assert.equal(this.fs.read('/output/nested/file.txt'), 'nested\n');
   });
 
+  it('copy by globbing multiple patterns', function () {
+    this.fs.copy([__dirname + '/fixtures/**', '!**/*tpl*'], '/output');
+    assert.equal(this.fs.read('/output/file-a.txt'), 'foo\n');
+    assert.equal(this.fs.read('/output/nested/file.txt'), 'nested\n');
+    assert.throws(this.fs.read.bind(this.fs, '/output/file-tpl.txt'));
+  });
+
   it('copy files by globbing and process contents', function () {
     var process = sinon.stub().returnsArg(0);
     this.fs.copy(__dirname + '/fixtures/**', '/output', { process: process });

--- a/test/util.js
+++ b/test/util.js
@@ -26,6 +26,10 @@ describe('util.getCommonPath()', function () {
   it('find the common root of glob /a/b/*.ext', function () {
     assert.equal(util.getCommonPath('/a/b/*.ext'), '/a/b');
   });
+
+  it('find the common root of multiple globs', function () {
+    assert.equal(util.getCommonPath(['/a/b/*.ext', '/a/b/c/*.ext', '!**/c/**']), '/a/b');
+  });
 });
 
 

--- a/util/util.js
+++ b/util/util.js
@@ -2,9 +2,22 @@
 
 var fs = require('fs');
 var path = require('path');
+var commondir = require('commondir');
 var glob = require('glob');
 
+function notNullOrExclusion(file) {
+  return file != null && file.charAt(0) !== '!';
+}
+
 exports.getCommonPath = function (filePath) {
+  if (Array.isArray(filePath)) {
+    filePath = filePath
+      .filter(notNullOrExclusion)
+      .map(this.getCommonPath.bind(this));
+
+    return commondir(filePath);
+  }
+
   filePath = this.globify(filePath);
   var globStartIndex = filePath.indexOf('*');
   if (globStartIndex !== -1) {
@@ -14,8 +27,11 @@ exports.getCommonPath = function (filePath) {
   return path.dirname(filePath);
 };
 
-
 exports.globify = function (filePath) {
+  if (Array.isArray(filePath)) {
+    return filePath.map(this.globify.bind(this));
+  }
+
   if (glob.hasMagic(filePath) || !fs.existsSync(filePath)) {
     return filePath;
   }


### PR DESCRIPTION
Supersedes PR [#30](https://github.com/SBoudrias/mem-fs-editor/pull/30). The previous implementation of array and multi-glob support caused the code to behave differently when given an array. This implementation embraces arrays and keeps the handling consistent.

When given an array the `util` methods will now iterate over the arrays and apply the pre-existing logic to each item in the array. The `getCommonPath` method will then additionally normalize the array to a single common string using `commondir`.

Both `.copy()` and `.delete()` have been updated to always use `globby.sync` in place of `glob.sync` and `multimatch` in place of `minimatch.match`.

None of the original tests were modified in any way. Additional tests were added to specifically test array handling.

@SBoudrias I'm not sure that this resolves your request to centralize the changes, but I think it's at least less divergent. Thoughts?