### PR TITLE
Allow empty string value in the defaults option for read().

### DIFF
--- a/actions/read.js
+++ b/actions/read.js
@@ -7,7 +7,12 @@ module.exports = function (path, options) {
   var file = this.store.get(path);
 
   if (file.state === 'deleted' || file.contents === null) {
-    file.contents = options.defaults ? new Buffer(options.defaults) : null;
+    if (typeof options.defaults === 'string' || options.defaults instanceof Buffer) {
+      file.contents = new Buffer(options.defaults);
+    }
+    else {
+      file.contents = null;
+    }
   }
 
   assert(file.contents !== null, path + ' doesn\'t exist');

--- a/test/read.js
+++ b/test/read.js
@@ -33,12 +33,17 @@ describe('#read()', function () {
     assert.throws(this.fs.read.bind(this.fs, 'file-who-does-not-exist.txt'));
   });
 
-  it('returns defaults as String if file does not exsit and defaults is provided', function () {
+  it('returns defaults as String if file does not exist and defaults is provided', function () {
     var content = this.fs.read('file-who-does-not-exist.txt', { defaults: 'foo\n' });
     assert.equal(content, 'foo\n');
   });
 
-  it('returns defaults as Buffer if file does not exsit and defaults is provided', function () {
+  it('returns defaults as String if file does not exist and defaults is provided as empty string', function () {
+    var content = this.fs.read('file-who-does-not-exist.txt', { defaults: '' });
+    assert.equal(content, '');
+  });
+
+  it('returns defaults as Buffer if file does not exist and defaults is provided', function () {
     var content = this.fs.read('file-who-does-not-exist.txt', {
       defaults: new Buffer('foo\n'),
       raw: true


### PR DESCRIPTION
This fixes #36 by testing whether `options.defaults` is a string or Buffer value rather than a truthy value, allowing an empty string as a default value. 

Fortunately there was a test passing in a Buffer rather than a string, I would not have caught that use case!