### PR TITLE
Enhance error message to include file name when failed to parse JSON

### DIFF
--- a/actions/read-json.js
+++ b/actions/read-json.js
@@ -2,7 +2,11 @@
 
 module.exports = function (path, defaults) {
   if (this.exists(path)) {
-    return JSON.parse(this.read(path));
+    try {
+      return JSON.parse(this.read(path));
+    } catch (error) {
+      throw new Error('Could not parse JSON in file: ' + path + '. Detail: ' + error.message);
+    }
   } else {
     return defaults;
   }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "vinyl": "^0.5.0"
   },
   "devDependencies": {
+    "escape-regexp": "0.0.1",
     "mem-fs": "^1.0.0",
     "mocha": "^2.1.0"
   }

--- a/test/read-json.js
+++ b/test/read-json.js
@@ -5,6 +5,7 @@ var path = require('path');
 var sinon = require('sinon');
 var editor = require('..');
 var memFs = require('mem-fs');
+var escape = require('escape-regexp');
 
 describe('#readJSON()', function () {
   beforeEach(function() {
@@ -33,5 +34,10 @@ describe('#readJSON()', function () {
 
   it('throw error if file could not be parsed as JSON, even if defaults is provided', function () {
     assert.throws(this.fs.readJSON.bind(this.fs, path.join(__dirname, 'fixtures/file-tpl.txt'), { foo: 'bar' }));
-  })
+  });
+
+  it('throw error with file path info', function () {
+    var filePath = path.join(__dirname, 'fixtures/file-tpl.txt');
+    assert.throws(this.fs.readJSON.bind(this.fs, filePath), new RegExp(escape(filePath)));
+  });
 });


### PR DESCRIPTION
Fixs #38 

New error message reads:
```
Error: Could not parse JSON in file: /Users/brianlai/Documents/projects/gh/mem-fs-editor/test/fixtures/file-tpl.txt. Detail: Unexpected token <
      at EditionInterface.module.exports [as readJSON] (/Users/brianlai/Documents/projects/gh/mem-fs-editor/actions/read-json.js:8:13)
      at Context.<anonymous> (/Users/brianlai/Documents/projects/gh/mem-fs-editor/test/read-json.js:41:45)
      ...
```