### PR TITLE
Add options to copyTpl

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,13 @@ Optionally, pass an `options.process` function (`process(contents)`) returning a
 
 `from` can be a glob pattern that'll be match against the file system. If that's the case, then `to` must be an output directory. For a globified `from`, you can optionally pass in an `options.globOptions` object to change its pattern matching behavior. The full list of options are being described [here](https://github.com/isaacs/node-glob#options). The `nodir` flag is forced to be `true` in `globOptions` to ensure a vinyl object representing each matching directory is marked as `deleted` in the `mem-fs` store.
 
-### `#copyTpl(from, to, context, [options])`
+### `#copyTpl(from, to, context[, templateOptions [, copyOptions]])`
 
 Copy the `from` file and parse its content as an [ejs](http://ejs.co/) template where `context` is the template context (the variable names available inside the template).
 
-You can optionally pass a template `options` object. `mem-fs-editor` automatically setup the filename option so you can easily use partials.
+You can optionally pass a `templateOptions` object. `mem-fs-editor` automatically setup the filename option so you can easily use partials.
+
+If you include a `templateOptions` object, you can also optionally pass a `copyOptions` object (see [copy() documentation for more details](https://github.com/SBoudrias/mem-fs-editor#copyfrom-to-options).
 
 Templates syntax looks like this:
 

--- a/lib/actions/copy-tpl.js
+++ b/lib/actions/copy-tpl.js
@@ -4,10 +4,10 @@ var path = require('path');
 var extend = require('deep-extend');
 var ejs = require('ejs');
 
-module.exports = function (from, to, context, tplSettings) {
+module.exports = function (from, to, context, tplSettings, options) {
   context = context || {};
 
-  this.copy(from, to, {
+  this.copy(from, to, extend(options || {}, {
     process: function (contents, filename) {
       return ejs.render(
         contents.toString(),
@@ -16,5 +16,5 @@ module.exports = function (from, to, context, tplSettings) {
         extend({filename: filename}, tplSettings || {})
       );
     }
-  });
+  }));
 };

--- a/test/copy-tpl.js
+++ b/test/copy-tpl.js
@@ -33,4 +33,20 @@ describe('#copyTpl()', function () {
     this.fs.copyTpl(filepath, newPath);
     assert.equal(this.fs.read(newPath), 'partial\n\n');
   });
+
+  it('allow including glob options', function() {
+    var filenames = [
+      path.join(__dirname, 'fixtures/file-tpl-partial.txt'),
+      path.join(__dirname, 'fixtures/file-tpl.txt')
+    ];
+    var copyOptions = {
+      globOptions: {
+        ignore: filenames[1]
+      }
+    };
+    var newPath = '/new/path';
+    this.fs.copyTpl(filenames, newPath, {}, {}, copyOptions);
+    assert.equal(this.fs.exists(path.join(newPath, 'file-tpl-partial.txt')), true);
+    assert.equal(this.fs.exists(path.join(newPath, 'file-tpl.txt')), false);
+  });
 });


### PR DESCRIPTION
Provides way for copyTpl() calls to include options that copy() has,
including glob options.

See #25