### PR TITLE
Fix readJSON docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ By default, calling `read()` on a file path that does not exist throws error. Yo
 
 Read a file and parse its contents as JSON.
 
-`readJSON()` internally calls `read()` and will throw error if the file path you pass in does not exist. But if you pass in an optional `defaults`, the `defaults` content will be returned in case of the target file is missing, instead of throwing error (error would still be thrown if JSON.parse failed to parse your target file).
+`readJSON()` internally calls `read()` but will not throw an error if the file path you pass in does not exist. If you pass in an optional `defaults`, the `defaults` content will be returned in case of the target file is missing, instead of `undefined`. (Error would still be thrown if `JSON.parse` failed to parse your target file.)
 
 ### `#write(filepath, contents)`
 


### PR DESCRIPTION
Currently the docs do not match the actual behavior of the library.

`readJSON` never actually attempts to read a non-existent file, but guards it with an `exists` call: https://github.com/SBoudrias/mem-fs-editor/blob/2c0ad362d9ed854b1558e5a0fbc0af3a7bd26e59/lib/actions/read-json.js#L4-L12