### PR TITLE
Misc improvements and fixes.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Node.js CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm test

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Optionally, pass an `options.process` function (`process(contents)`) returning a
 
 `from` can be a glob pattern that'll be match against the file system. If that's the case, then `to` must be an output directory. For a globified `from`, you can optionally pass in an `options.globOptions` object to change its pattern matching behavior. The full list of options are being described [here](https://github.com/mrmlnc/fast-glob#options-1). The `nodir` flag is forced to be `true` in `globOptions` to ensure a vinyl object representing each matching directory is marked as `deleted` in the `mem-fs` store.
 
+Optionally, when `from` is a glob pattern, pass an `options.processDestinationPath` function (`processDestinationPath(destinationFile)`) returning a string who'll become the new file name.
+
 ### `#copyTpl(from, to, context[, templateOptions [, copyOptions]])`
 
 Copy the `from` file and, if it is not a binary file, parse its content as an [ejs](http://ejs.co/) template where `context` is the template context (the variable names available inside the template).

--- a/__tests__/copy-tpl.js
+++ b/__tests__/copy-tpl.js
@@ -68,4 +68,16 @@ describe('#copyTpl()', () => {
     fs.copyTpl(pathCopied, newPath);
     expect(fs.read(newPath)).toBe(fs.read(filepath));
   });
+
+  it('allow passing circular function context', function () {
+    const b = {};
+    const a = {name: 'new content', b};
+    b.a = a;
+    const filepath = path.join(__dirname, 'fixtures/file-circular.txt');
+    const newPath = '/new/path/file.txt';
+    fs.copyTpl(filepath, newPath, {}, {
+      context: {a}
+    });
+    expect(fs.read(newPath)).toBe('new content new content' + os.EOL);
+  });
 });

--- a/__tests__/copy-tpl.js
+++ b/__tests__/copy-tpl.js
@@ -80,4 +80,18 @@ describe('#copyTpl()', () => {
     });
     expect(fs.read(newPath)).toBe('new content new content' + os.EOL);
   });
+
+  it('removes ejs extension when globbing', function () {
+    const filepath = path.join(__dirname, 'fixtures/ejs');
+    const newPath = '/new/path/';
+    fs.copyTpl(filepath, newPath);
+    expect(fs.exists(path.join(newPath, 'file-ejs-extension.txt'))).toBeTruthy();
+  });
+
+  it('doens\'t removes ejs extension when not globbing', function () {
+    const filepath = path.join(__dirname, 'fixtures/ejs/file-ejs-extension.txt.ejs');
+    const newPath = '/new/path/file-ejs-extension.txt.ejs';
+    fs.copyTpl(filepath, newPath);
+    expect(fs.exists(newPath)).toBeTruthy();
+  });
 });

--- a/__tests__/copy.js
+++ b/__tests__/copy.js
@@ -84,7 +84,7 @@ describe('#copy()', () => {
     let outputDir = path.join(__dirname, '../test/output');
     const process = sinon.stub().returnsArg(0);
     fs.copy(path.join(__dirname, '/fixtures/**'), outputDir, {process});
-    sinon.assert.callCount(process, 9); // 8 total files under 'fixtures', not counting folders
+    sinon.assert.callCount(process, 10); // 8 total files under 'fixtures', not counting folders
     expect(fs.read(path.join(outputDir, 'file-a.txt'))).toBe('foo' + os.EOL);
     expect(fs.read(path.join(outputDir, '/nested/file.txt'))).toBe('nested' + os.EOL);
   });

--- a/__tests__/copy.js
+++ b/__tests__/copy.js
@@ -84,7 +84,7 @@ describe('#copy()', () => {
     let outputDir = path.join(__dirname, '../test/output');
     const process = sinon.stub().returnsArg(0);
     fs.copy(path.join(__dirname, '/fixtures/**'), outputDir, {process});
-    sinon.assert.callCount(process, 8); // 7 total files under 'fixtures', not counting folders
+    sinon.assert.callCount(process, 9); // 8 total files under 'fixtures', not counting folders
     expect(fs.read(path.join(outputDir, 'file-a.txt'))).toBe('foo' + os.EOL);
     expect(fs.read(path.join(outputDir, '/nested/file.txt'))).toBe('nested' + os.EOL);
   });

--- a/__tests__/fixtures/file-circular.txt
+++ b/__tests__/fixtures/file-circular.txt
@@ -1,0 +1,1 @@
+<%= this.a.name %> <%= this.a.b.a.name %>

--- a/lib/actions/append.js
+++ b/lib/actions/append.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var extend = require('deep-extend');
 var EOL = require('os').EOL;
 
 module.exports = function (to, contents, options) {
-  options = extend({
+  options = {
     trimEnd: true,
-    separator: EOL
-  }, options || {});
+    separator: EOL,
+    ...options
+  };
 
   var currentContents = this.read(to);
   if (options.trimEnd) {

--- a/lib/actions/copy-tpl.js
+++ b/lib/actions/copy-tpl.js
@@ -29,6 +29,7 @@ module.exports = function (from, to, context, tplSettings, options) {
     from,
     to,
     {
+      processDestinationPath: path => path.replace(/.ejs$/, ''),
       ...options,
       process: function (contents, filename) {
         return render(contents, filename, context, tplSettings);

--- a/lib/actions/copy-tpl.js
+++ b/lib/actions/copy-tpl.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var extend = require('deep-extend');
 var ejs = require('ejs');
 var isBinaryFileSync = require('isbinaryfile').isBinaryFileSync;
 
@@ -15,7 +14,7 @@ function render(contents, filename, context, tplSettings) {
       contents.toString(),
       context,
       // Setting filename by default allow including partials.
-      extend({filename: filename}, tplSettings)
+      {filename: filename, ...tplSettings}
     );
   }
 
@@ -29,11 +28,12 @@ module.exports = function (from, to, context, tplSettings, options) {
   this.copy(
     from,
     to,
-    extend(options || {}, {
+    {
+      ...options,
       process: function (contents, filename) {
         return render(contents, filename, context, tplSettings);
       }
-    }),
+    },
     context,
     tplSettings
   );

--- a/lib/actions/copy.js
+++ b/lib/actions/copy.js
@@ -37,10 +37,11 @@ exports.copy = function (from, to, options, context, tplSettings) {
       'When copying multiple files, provide a directory as destination'
     );
 
+    const processDestinationPath = options.processDestinationPath || (path => path);
     var root = util.getCommonPath(from);
     generateDestination = filepath => {
       var toFile = path.relative(root, filepath);
-      return path.join(to, toFile);
+      return processDestinationPath(path.join(to, toFile));
     };
   }
 

--- a/lib/actions/copy.js
+++ b/lib/actions/copy.js
@@ -5,7 +5,6 @@ var fs = require('fs');
 var path = require('path');
 var glob = require('glob');
 var globby = require('globby');
-var extend = require('deep-extend');
 var multimatch = require('multimatch');
 var ejs = require('ejs');
 var util = require('../util');
@@ -20,7 +19,7 @@ exports.copy = function (from, to, options, context, tplSettings) {
   options = options || {};
   var fromGlob = util.globify(from);
 
-  var globOptions = extend(options.globOptions || {}, {nodir: true});
+  var globOptions = {...options.globOptions, nodir: true};
   var diskFiles = globby.sync(fromGlob, globOptions);
   var storeFiles = [];
   this.store.each(file => {

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "collectCoverage": true,
     "coverageDirectory": "coverage",
     "testEnvironment": "node"
+  },
+  "engines": {
+    "node": ">=10.0.0"
   }
 }


### PR DESCRIPTION
- When passing a circular object function context to `copyTemplate()` deep-extend throws an error.
So use spread (node >= 8.3.0) instead of deep-extend where applicable.
- Implement `options.processDestinationPath` support when `from` is a glob and remove ejs extension by default for `copyTpl()`.
- Add github workflow
- Add to engines node >= 10