### PR TITLE
add appendTpl

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ Append the new contents to the current file contents.
 - `options.trimEnd` (default `true`). Trim trailing whitespace of the current file contents.
 - `options.separator` (default `os.EOL`). Separator to insert between current and new contents.
 
+### `#appendTpl(filepath, contents, context[, templateOptions[, [options]])`
+
+Append the new `contents` to the exsting `filepath` content and parse the new contents as an [ejs](http://ejs.co/) template where `context` is the template context (the variable names available inside the template).
+
+- `options.trimEnd` (default `true`). Trim trailing whitespace of the current file contents.
+- `options.separator` (default `os.EOL`). Separator to insert between current and new contents.
+
 ### `#extendJSON(filepath, contents[, replacer [, space]])`
 
 Extend the content of an existing JSON file with the partial objects provided as argument.

--- a/__tests__/append-tpl.js
+++ b/__tests__/append-tpl.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+const editor = require('..');
+const memFs = require('mem-fs');
+
+describe('#appendTpl()', () => {
+  let store;
+  let fs;
+
+  beforeEach(() => {
+    store = memFs.create();
+    fs = editor.create(store);
+  });
+
+  it('appends to file and processes contents as underscore template', () => {
+    const filepath = path.join(__dirname, 'fixtures/file-a.txt');
+    const orginalContent = fs.read(filepath).toString();
+    const contentPath = path.join(__dirname, 'fixtures/file-tpl.txt');
+    const contents = fs.read(contentPath);
+    fs.appendTpl(filepath, contents, {
+      name: 'bar'
+    });
+    expect(fs.read(filepath)).toBe(orginalContent + 'bar' + os.EOL);
+  });
+
+  it('allows setting custom template delimiters', () => {
+    const filepath = path.join(__dirname, 'fixtures/file-a.txt');
+    const orginalContent = fs.read(filepath).toString();
+    const contentPath = path.join(__dirname, 'fixtures/file-tpl-custom-delimiter.txt');
+    const contents = fs.read(contentPath);
+    fs.appendTpl(filepath, contents, {
+      name: 'bar'
+    },
+    {
+      delimiter: '?'
+    });
+    expect(fs.read(filepath)).toBe(orginalContent + 'bar' + os.EOL);
+  });
+
+  it('throws an exception when no template data passed', () => {
+    const f = () => {
+      const filepath = path.join(__dirname, 'fixtures/file-a.txt');
+      const contentPath = path.join(__dirname, 'fixtures/file-tpl.txt');
+      const contents = fs.read(contentPath);
+      fs.appendTpl(filepath, contents);
+    };
+
+    expect(f).toThrow(ReferenceError);
+  });
+});

--- a/lib/actions/append-tpl.js
+++ b/lib/actions/append-tpl.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var ejs = require('ejs');
+
+module.exports = function (to, contents, context, tplSettings, options) {
+  context = context || {};
+  tplSettings = tplSettings || {};
+
+  this.append(
+    to,
+    ejs.render(
+      contents.toString(),
+      context,
+      tplSettings
+    ),
+    options);
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ EditionInterface.prototype.write = require('./actions/write.js');
 EditionInterface.prototype.writeJSON = require('./actions/write-json.js');
 EditionInterface.prototype.extendJSON = require('./actions/extend-json.js');
 EditionInterface.prototype.append = require('./actions/append.js');
+EditionInterface.prototype.appendTpl = require('./actions/append-tpl.js');
 EditionInterface.prototype.delete = require('./actions/delete.js');
 EditionInterface.prototype.copy = require('./actions/copy.js').copy;
 EditionInterface.prototype._copySingle = require('./actions/copy.js')._copySingle;


### PR DESCRIPTION
Add: appendTpl(filepath, contents, context[, templateOptions[, [options]])

This acts as an overload to append() allowing the new content to be parsed as an ejs template prior to appending.
The behaviour of append() is not changed.