### PR TITLE
Reimplement state processing

### DIFF
--- a/__tests__/delete.js
+++ b/__tests__/delete.js
@@ -13,42 +13,50 @@ describe('#delete()', () => {
     fs = editor.create(store);
   });
 
-  it('deletes a file', () => {
+  it('deletes existing files', () => {
     const filepath = path.join(__dirname, 'fixtures/file-a.txt');
     fs.delete(filepath);
     expect(fs.read.bind(fs, filepath)).toThrow();
-    expect(fs.store.get(filepath).state).toBe('deleted');
+
+    const file = fs.store.get(filepath);
+    expect(file.contents).toBe(null);
+    expect(file.state).toBe('deleted');
   });
 
-  it('deletes a directory', () => {
+  it('deletes a directory with existing files', () => {
     const dirpath = path.join(__dirname, 'fixtures/nested');
     const nestedFile = path.join(dirpath, 'file.txt');
     fs.delete(dirpath);
-    expect(fs.store.get(nestedFile).state).toBe('deleted');
+
+    const file = fs.store.get(nestedFile);
+    expect(file.contents).toBe(null);
+    expect(file.state).toBe('deleted');
   });
 
   it('deletes new files', () => {
     fs.write('foo', 'foo');
     fs.delete('foo');
-    expect(fs.store.get('foo').state).toBe('deleted');
+
+    const file = fs.store.get('foo');
+    expect(file.contents).toBe(null);
+    expect(file.state).toBe('deleted');
   });
 
   it('deletes new directories', () => {
     fs.write('/test/bar/foo.txt', 'foo');
     fs.delete('/test/bar/');
-    expect(fs.store.get('/test/bar/foo.txt').state).toBe('deleted');
-  });
 
-  it('after delete a file should set isNew flag on write', () => {
-    const filepath = path.join(__dirname, 'fixtures/file-a.txt');
-    fs.delete(filepath);
-    fs.write(filepath, 'foo');
-    expect(fs.store.get(filepath).isNew).toBeTruthy();
+    const file = fs.store.get('/test/bar/foo.txt');
+    expect(file.contents).toBe(null);
+    expect(file.state).toBe('deleted');
   });
 
   it('delete new files if specifying a full path', () => {
     fs.write('bar', 'bar');
     fs.delete(path.resolve('bar'));
-    expect(fs.store.get('bar').state).toBe('deleted');
+
+    const file = fs.store.get('bar');
+    expect(file.contents).toBe(null);
+    expect(file.state).toBe('deleted');
   });
 });

--- a/__tests__/state.js
+++ b/__tests__/state.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const path = require('path');
+const state = require('..').State;
+
+describe('state', () => {
+  let file;
+  beforeEach(() => {
+    file = {};
+  });
+
+  it('setModifiedFileState()/isFileStateModified()', () => {
+    expect(file.state).toBe(undefined);
+    expect(state.isFileStateModified(file)).toBe(false);
+
+    state.setModifiedFileState(file);
+
+    expect(file.state).toBe('modified');
+    expect(state.isFileStateModified(file)).toBe(true);
+  });
+
+  it('setDeletedFileState()/isFileStateDeleted()', () => {
+    expect(file.state).toBe(undefined);
+    expect(state.isFileStateDeleted(file)).toBe(false);
+
+    state.setDeletedFileState(file);
+
+    expect(file.state).toBe('deleted');
+    expect(state.isFileStateDeleted(file)).toBe(true);
+  });
+
+  it('setCommittedFile()/fileStateIsCommitted()', () => {
+    expect(file.committed).toBe(undefined);
+    expect(state.isFileCommitted(file)).toBe(false);
+
+    state.setCommittedFile(file);
+
+    expect(file.committed).toBe(true);
+    expect(state.isFileCommitted(file)).toBe(true);
+  });
+
+  it('resetFileState()', () => {
+    file.state = 'foo';
+    file.isNew = true;
+
+    state.resetFileState(file);
+
+    expect(file.state).toBe(undefined);
+    expect(file.isNew).toBe(true);
+  });
+
+  it('clearFileState()', () => {
+    file.state = 'foo';
+    file.isNew = true;
+
+    state.clearFileState(file);
+
+    expect(file.state).toBe(undefined);
+    expect(file.clearedState).toBe(file.state);
+    expect(file.isNew).toBe(undefined);
+    expect(state.hasClearedState(file)).toBe(true);
+  });
+
+  describe('isFileNew()', () => {
+    it('with new file', () => {
+      expect(file.isNew).toBe(undefined);
+      file.path = 'foo';
+
+      expect(state.isFileNew(file)).toBe(true);
+      expect(file.isNew).toBe(true);
+    });
+
+    it('with existing file', () => {
+      expect(file.isNew).toBe(undefined);
+      file.path = path.join(__dirname, 'fixtures/file-a.txt');
+
+      expect(state.isFileNew(file)).toBe(false);
+      expect(file.isNew).toBe(false);
+    });
+  });
+
+  describe('isFilePending()', () => {
+    it('unkown state', () => {
+      expect(state.isFilePending(file)).toBe(false);
+    });
+
+    it('modified state', () => {
+      state.setModifiedFileState(file);
+      expect(state.isFilePending(file)).toBe(true);
+    });
+
+    it('delete state and new file', () => {
+      file.path = 'foo';
+      state.setDeletedFileState(file);
+      expect(state.isFilePending(file)).toBe(false);
+    });
+
+    it('delete state and existing file', () => {
+      file.path = path.join(__dirname, 'fixtures/file-a.txt');
+      state.setDeletedFileState(file);
+      expect(state.isFilePending(file)).toBe(true);
+    });
+  });
+});

--- a/lib/actions/commit-file-async.js
+++ b/lib/actions/commit-file-async.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs').promises;
 var path = require('path');
+var {clearFileState, isFileStateModified, isFileStateDeleted, setCommittedFile} = require('../state');
 
 async function write(file) {
   var dir = path.dirname(file.path);
@@ -28,14 +29,13 @@ async function remove(file) {
 
 module.exports = async function (file) {
   this.store.add(file);
-  if (file.state === 'modified') {
-    file.committed = true;
+  if (isFileStateModified(file)) {
+    setCommittedFile(file);
     await write(file);
-  } else if (file.state === 'deleted') {
-    file.committed = true;
+  } else if (isFileStateDeleted(file)) {
+    setCommittedFile(file);
     await remove(file);
   }
 
-  delete file.state;
-  delete file.isNew;
+  clearFileState(file);
 };

--- a/lib/actions/commit.js
+++ b/lib/actions/commit.js
@@ -2,6 +2,7 @@
 
 var {pipeline} = require('stream');
 const {createTransform} = require('../util');
+const {isFilePending} = require('../state');
 
 module.exports = function (filters, stream, cb) {
   var self = this;
@@ -18,7 +19,7 @@ module.exports = function (filters, stream, cb) {
   stream = stream || this.store.stream();
   var modifiedFilter = createTransform(function (file, _enc, cb) {
     // Don't process deleted file who haven't been commited yet.
-    if (file.state === 'modified' || (file.state === 'deleted' && !file.isNew)) {
+    if (isFilePending(file)) {
       this.push(file);
     }
 

--- a/lib/actions/delete.js
+++ b/lib/actions/delete.js
@@ -4,10 +4,11 @@ var path = require('path');
 var globby = require('globby');
 var multimatch = require('multimatch');
 var util = require('../util');
+var {setDeletedFileState} = require('../state');
 
 function deleteFile(path, store) {
   var file = store.get(path);
-  file.state = 'deleted';
+  setDeletedFileState(file);
   file.contents = null;
   store.add(file);
 }

--- a/lib/actions/exists.js
+++ b/lib/actions/exists.js
@@ -3,5 +3,5 @@
 module.exports = function (filepath) {
   var file = this.store.get(filepath);
 
-  return file.contents !== null && file.state !== 'deleted';
+  return file.contents !== null;
 };

--- a/lib/actions/read.js
+++ b/lib/actions/read.js
@@ -4,7 +4,7 @@ module.exports = function (filepath, options) {
   options = options || {raw: false};
   var file = this.store.get(filepath);
 
-  if (file.state === 'deleted' || file.contents === null) {
+  if (file.contents === null) {
     if ('defaults' in options) {
       return options.defaults;
     }

--- a/lib/actions/write.js
+++ b/lib/actions/write.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var assert = require('assert');
+var {setModifiedFileState} = require('../state');
 
 module.exports = function (filepath, contents, stat) {
   assert(
@@ -9,8 +10,7 @@ module.exports = function (filepath, contents, stat) {
   );
 
   var file = this.store.get(filepath);
-  file.isNew = file.contents === null;
-  file.state = 'modified';
+  setModifiedFileState(file);
   file.contents = typeof contents === 'string' ? Buffer.from(contents) : contents;
   file.stat = stat;
   this.store.add(file);

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,3 +26,5 @@ EditionInterface.prototype.commitFileAsync = require('./actions/commit-file-asyn
 exports.create = function (store) {
   return new EditionInterface(store);
 };
+
+exports.State = require('./state');

--- a/lib/state.js
+++ b/lib/state.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+
+const STATE = 'state';
+
+const STATE_CLEARED = 'stateCleared';
+
+const STATE_MODIFIED = 'modified';
+
+const STATE_DELETED = 'deleted';
+
+const IS_NEW = 'isNew';
+
+const setFileState = (file, state) => {
+  file[STATE] = state;
+};
+
+const isFileNew = file => {
+  if (file[IS_NEW] === undefined) {
+    file[IS_NEW] = !fs.existsSync(file.path);
+  }
+
+  return file[IS_NEW];
+};
+
+const isFileStateModified = file => file[STATE] === STATE_MODIFIED;
+
+const setModifiedFileState = file => setFileState(file, STATE_MODIFIED);
+
+const isFileStateDeleted = file => file[STATE] === STATE_DELETED;
+
+const setDeletedFileState = file => setFileState(file, STATE_DELETED);
+
+const isFilePending = file => isFileStateModified(file) || (isFileStateDeleted(file) && !isFileNew(file));
+
+const setCommittedFile = file => {
+  file.committed = true;
+};
+
+const isFileCommitted = file => Boolean(file.committed);
+
+const resetFileState = file => {
+  delete file[STATE];
+};
+
+const clearFileState = file => {
+  if (file[STATE]) {
+    file[STATE_CLEARED] = file[STATE];
+  }
+
+  resetFileState(file);
+  delete file[IS_NEW];
+};
+
+const hasClearedState = file => Boolean(file[STATE_CLEARED]);
+
+module.exports = {
+  STATE,
+  STATE_CLEARED,
+  STATE_MODIFIED,
+  STATE_DELETED,
+  isFileStateModified,
+  setModifiedFileState,
+  isFileStateDeleted,
+  setDeletedFileState,
+  setCommittedFile,
+  isFileCommitted,
+  isFileNew,
+  isFilePending,
+  resetFileState,
+  clearFileState,
+  hasClearedState
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -90,4 +90,3 @@ exports.render = function (contents, context, tplSettings) {
 
   return result;
 };
-


### PR DESCRIPTION
Fixes wrong `isNew` state:
- an existing file deletion will not be committed with the operation sequence: delete, write, delete.

Changes some behaviors:
- Implement api for file state processing.
- `isNew` is processed at commit time only by testing the existence in the disc.
- Don't test deleted state and null contents. A deleted file contents should be always null.