### PR TITLE
Add noGlob option (fix #75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Optionally, pass an `options.process` function (`process(contents)`) returning a
 
 Optionally, when `from` is a glob pattern, pass an `options.processDestinationPath` function (`processDestinationPath(destinationFile)`) returning a string who'll become the new file name.
 
+`options.noGlob` can be used to by bypass glob matching entirely. In that case, `from` will directly match file paths against the file system.
+
 ### `#copyAsync(from, to, [options], context[, templateOptions ])`
 
 Async version of `copy`.

--- a/__tests__/__snapshots__/commit.js.snap
+++ b/__tests__/__snapshots__/commit.js.snap
@@ -411,6 +411,11 @@ Object {
     "contents": "",
     "stateCleared": "modified",
   },
+  "file-(specia!-char$).txt": Object {
+    "contents": "special
+",
+    "stateCleared": "modified",
+  },
   "file-a.txt": Object {
     "contents": "foo
 ",
@@ -468,6 +473,11 @@ exports[`#copyTpl() and #commit() should match snapshot 1`] = `
 Object {
   "ejs/file-ejs-extension.txt": Object {
     "contents": "",
+    "stateCleared": "modified",
+  },
+  "file-(specia!-char$).txt": Object {
+    "contents": "special
+",
     "stateCleared": "modified",
   },
   "file-a.txt": Object {

--- a/__tests__/copy-async.js
+++ b/__tests__/copy-async.js
@@ -120,7 +120,7 @@ describe('#copyAsync()', () => {
       return this.store.get(from).contents;
     });
     await fs.copyAsync(path.join(__dirname, '/fixtures/**'), outputDir, {processFile});
-    sinon.assert.callCount(processFile, 11); // 9 total files under 'fixtures', not counting folders
+    sinon.assert.callCount(processFile, 12); // 10 total files under 'fixtures', not counting folders
     expect(fs.read(path.join(outputDir, 'file-a.txt'))).toBe('foo' + os.EOL);
     expect(fs.read(path.join(outputDir, '/nested/file.txt'))).toBe('nested' + os.EOL);
   });

--- a/__tests__/copy.js
+++ b/__tests__/copy.js
@@ -120,7 +120,7 @@ describe('#copy()', () => {
     const outputDir = path.join(__dirname, '../test/output');
     const process = sinon.stub().returnsArg(0);
     fs.copy(path.join(__dirname, '/fixtures/**'), outputDir, {process});
-    sinon.assert.callCount(process, 11); // 9 total files under 'fixtures', not counting folders
+    sinon.assert.callCount(process, 12); // 10 total files under 'fixtures', not counting folders
     expect(fs.read(path.join(outputDir, 'file-a.txt'))).toBe('foo' + os.EOL);
     expect(fs.read(path.join(outputDir, '/nested/file.txt'))).toBe('nested' + os.EOL);
   });
@@ -168,5 +168,11 @@ describe('#copy()', () => {
       expect(newStat.mode).toBe(oldStat.mode);
       done();
     });
+  });
+
+  it('copy with globbing disabled', () => {
+    const newPath = path.join(__dirname, '../test/output', 'file.txt');
+    fs.copy(path.join(__dirname, '/fixtures/file-(specia!-char$).txt'), newPath, {noGlob: true});
+    expect(fs.read(newPath)).toBe('special' + os.EOL);
   });
 });

--- a/__tests__/fixtures/file-(specia!-char$).txt
+++ b/__tests__/fixtures/file-(specia!-char$).txt
@@ -1,0 +1,1 @@
+special

--- a/lib/actions/copy.js
+++ b/lib/actions/copy.js
@@ -19,8 +19,15 @@ exports.copy = function (from, to, options, context, tplSettings) {
   options = options || {};
   const fromGlob = util.globify(from);
 
-  const globOptions = {...options.globOptions, nodir: true};
-  const diskFiles = globby.sync(fromGlob, globOptions).map(file => path.resolve(file));
+  let diskFiles = [];
+  if (options.noGlob) {
+    const fromFiles = Array.isArray(fromGlob) ? fromGlob : [fromGlob];
+    diskFiles = fromFiles.filter(filepath => fs.existsSync(filepath));
+  } else {
+    const globOptions = {...options.globOptions, nodir: true};
+    diskFiles = globby.sync(fromGlob, globOptions).map(file => path.resolve(file));
+  }
+
   const storeFiles = [];
   this.store.each(file => {
     // The store may have a glob path and when we try to copy it will fail because not real file


### PR DESCRIPTION
I tried to keep the changes minimal, while making this to work.

A test was added with a file containing special glob characters, that fails to copy without this option.
I also had to update some other test as I needed to add a new files in fixture dir.