### PR TITLE
Only add to mem-fs when the file has changed.

### DIFF
--- a/__tests__/commit-file-async.js
+++ b/__tests__/commit-file-async.js
@@ -4,6 +4,7 @@ const filesystem = require('fs');
 const os = require('os');
 const path = require('path');
 const memFs = require('mem-fs');
+const sinon = require('sinon');
 const editor = require('..');
 
 const rmSync = filesystem.rmSync || filesystem.rmdirSync;
@@ -12,15 +13,19 @@ describe('#commit()', () => {
   const outputRoot = path.join(os.tmpdir(), 'mem-fs-editor-test');
   const outputDir = path.join(outputRoot, 'output');
   const filename = path.join(outputDir, 'file.txt');
+  const filenameNew = path.join(outputDir, 'file-new.txt');
 
   let store;
   let fs;
 
   beforeEach(() => {
     store = memFs.create();
-    fs = editor.create(store);
+    sinon.spy(store, 'add');
 
+    fs = editor.create(store);
     fs.write(filename, 'foo');
+
+    expect(store.add.callCount).toEqual(1);
   });
 
   afterEach(() => {
@@ -30,5 +35,15 @@ describe('#commit()', () => {
   it('triggers callback when done', async () => {
     await fs.commitFileAsync(store.get(filename));
     expect(filesystem.readFileSync(filename).toString()).toEqual('foo');
+  });
+
+  it('adds non existing file to store', async () => {
+    await fs.commitFileAsync({path: filenameNew, contents: Buffer.from('bar'), state: 'modified'});
+    expect(store.add.callCount).toEqual(2);
+  });
+
+  it('doesn\'t readd same file to store', async () => {
+    await fs.commitFileAsync(store.get(filename));
+    expect(store.add.callCount).toEqual(1);
   });
 });

--- a/__tests__/write.js
+++ b/__tests__/write.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const sinon = require('sinon');
 const editor = require('..');
 const memFs = require('mem-fs');
 
@@ -10,6 +11,8 @@ describe('#write()', () => {
 
   beforeEach(() => {
     store = memFs.create();
+    sinon.spy(store, 'add');
+
     fs = editor.create(store);
   });
 
@@ -35,5 +38,17 @@ describe('#write()', () => {
     fs.write(filepath, contents);
     expect(fs.read(filepath)).toBe(contents);
     expect(fs.store.get(filepath).state).toBe('modified');
+  });
+
+  it('doesn\'t re-add an identical file that already exist in memory', () => {
+    const filepath = path.join(__dirname, 'fixtures/file-a.txt');
+    const contents = 'some text';
+    fs.write(filepath, contents);
+    expect(store.add.callCount).toBe(1);
+    expect(fs.read(filepath)).toBe(contents);
+    expect(fs.store.get(filepath).state).toBe('modified');
+
+    fs.write(filepath, contents);
+    expect(store.add.callCount).toBe(1);
   });
 });

--- a/lib/actions/commit-file-async.js
+++ b/lib/actions/commit-file-async.js
@@ -32,7 +32,11 @@ async function remove(file) {
 }
 
 module.exports = async function (file) {
-  this.store.add(file);
+  const existingFile = this.store.get(file.path);
+  if (!existingFile || existingFile !== file) {
+    this.store.add(file);
+  }
+
   if (isFileStateModified(file)) {
     setCommittedFile(file);
     await write(file);

--- a/lib/actions/write.js
+++ b/lib/actions/write.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('assert');
-const {setModifiedFileState} = require('../state');
+const {isFileStateModified, setModifiedFileState} = require('../state');
 
 module.exports = function (filepath, contents, stat) {
   assert(
@@ -10,10 +10,18 @@ module.exports = function (filepath, contents, stat) {
   );
 
   const file = this.store.get(filepath);
-  setModifiedFileState(file);
-  file.contents = Buffer.isBuffer(contents) ? contents : Buffer.from(contents);
-  file.stat = stat;
-  this.store.add(file);
+  const newContents = Buffer.isBuffer(contents) ? contents : Buffer.from(contents);
+  if (
+    !isFileStateModified(file)
+    || !Buffer.isBuffer(file.contents)
+    || !newContents.equals(file.contents)
+    || (stat !== undefined && file.stat !== stat)
+  ) {
+    setModifiedFileState(file);
+    file.contents = newContents;
+    file.stat = stat;
+    this.store.add(file);
+  }
 
   return file.contents.toString();
 };


### PR DESCRIPTION
Change event is triggered for every mem-fs add call.
- A full commit will trigger change event for every file.
- A write operation will trigger change event even if it hasn't changed.

This PR adds checks to don't add same file for commits and don't add unchanged file.