### PR TITLE
apply state filter to dump with pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,4 +152,5 @@ If provided, `stream` is a stream of vinyl files.
 
 Dump files to compare expected result.
 Provide a `cwd` for relative path. Allows to omit temporary path.
-Provide a `filter` function or glob to focus on specific files.
+Provide a `filter` function or a pattern to focus on specific files.
+`dump` returns only modified (committed or not) files when no filter or a pattern is provided.

--- a/__tests__/__snapshots__/dump.js.snap
+++ b/__tests__/__snapshots__/dump.js.snap
@@ -31,11 +31,15 @@ Object {
 }
 `;
 
-exports[`#dump() with a glob pattern should match snapshot 1`] = `
+exports[`#dump() with a glob pattern should return files that matches the pattern and have state or stateCleared 1`] = `
 Object {
   "foo/committed": Object {
     "contents": "committed",
     "stateCleared": "modified",
+  },
+  "foo/not-committed": Object {
+    "contents": "not-committed",
+    "state": "modified",
   },
 }
 `;

--- a/__tests__/dump.js
+++ b/__tests__/dump.js
@@ -44,8 +44,8 @@ describe('#dump()', () => {
   });
 
   describe('with a glob pattern', () => {
-    it('should match snapshot', () => {
-      expect(fs.dump(output, '**/committed')).toMatchSnapshot();
+    it('should return files that matches the pattern and have state or stateCleared', () => {
+      expect(fs.dump(output, '**/*committed')).toMatchSnapshot();
     });
   });
 });

--- a/lib/actions/dump.js
+++ b/lib/actions/dump.js
@@ -6,13 +6,12 @@ const minimatch = require('minimatch');
 
 const { hasClearedState, hasState, STATE, STATE_CLEARED } = require('../state');
 
-module.exports = function (
-  cwd = process.cwd(),
-  filter = (file) => hasClearedState(file) || hasState(file)
-) {
+const defaultDumpFilter = (file) => hasClearedState(file) || hasState(file);
+
+module.exports = function (cwd = process.cwd(), filter = defaultDumpFilter) {
   if (typeof filter === 'string') {
     const pattern = filter;
-    filter = (file) => minimatch(file.path, pattern);
+    filter = (file) => defaultDumpFilter(file) && minimatch(file.path, pattern);
   }
 
   return Object.fromEntries(


### PR DESCRIPTION
`dump` can return false positives when using pattern.
If a file that matches the pattern is read and added to the memory fs, that file will be returned at dump with pattern.