### PR TITLE
add default filter to stream

### DIFF
--- a/lib/actions/commit.js
+++ b/lib/actions/commit.js
@@ -5,6 +5,7 @@ const { pipeline: _pipeline } = require('stream');
 const pipeline = promisify(_pipeline);
 
 const { createPendingFilesPassthrough, createCommitTransform } = require('../transform');
+const { isFilePending } = require('../state');
 
 module.exports = function (filters, stream, cb) {
   if (typeof filters === 'function') {
@@ -16,7 +17,7 @@ module.exports = function (filters, stream, cb) {
     stream = undefined;
   }
 
-  stream = stream || this.store.stream();
+  stream = stream || this.store.stream({ filter: (file) => isFilePending(file) });
   filters = filters || [];
 
   const promise = pipeline(

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "eslint-config-xo": "^0.39.0",
         "eslint-plugin-prettier": "^4.0.0",
         "jest": "^27.0.6",
-        "mem-fs": "^2.2.1",
+        "mem-fs": "^2.3.0",
         "prettier": "^2.5.1",
         "sinon": "^12.0.1"
       },
@@ -5746,12 +5746,12 @@
       }
     },
     "node_modules/mem-fs": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-2.2.1.tgz",
-      "integrity": "sha512-yiAivd4xFOH/WXlUi6v/nKopBh1QLzwjFi36NK88cGt/PRXI8WeBASqY+YSjIVWvQTx3hR8zHKDBMV6hWmglNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-2.3.0.tgz",
+      "integrity": "sha512-GftCCBs6EN8sz3BoWO1bCj8t7YBtT713d8bUgbhg9Iel5kFSqnSvCK06TYIDJAtJ51cSiWkM/YemlT0dfoFycw==",
       "dev": true,
       "dependencies": {
-        "@types/node": "^15.6.1",
+        "@types/node": "^15.6.2",
         "@types/vinyl": "^2.0.4",
         "vinyl": "^2.0.1",
         "vinyl-file": "^3.0.0"
@@ -11713,12 +11713,12 @@
       }
     },
     "mem-fs": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-2.2.1.tgz",
-      "integrity": "sha512-yiAivd4xFOH/WXlUi6v/nKopBh1QLzwjFi36NK88cGt/PRXI8WeBASqY+YSjIVWvQTx3hR8zHKDBMV6hWmglNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-2.3.0.tgz",
+      "integrity": "sha512-GftCCBs6EN8sz3BoWO1bCj8t7YBtT713d8bUgbhg9Iel5kFSqnSvCK06TYIDJAtJ51cSiWkM/YemlT0dfoFycw==",
       "dev": true,
       "requires": {
-        "@types/node": "^15.6.1",
+        "@types/node": "^15.6.2",
         "@types/vinyl": "^2.0.4",
         "vinyl": "^2.0.1",
         "vinyl-file": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-config-xo": "^0.39.0",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.0.6",
-    "mem-fs": "^2.2.1",
+    "mem-fs": "^2.3.0",
     "prettier": "^2.5.1",
     "sinon": "^12.0.1"
   },


### PR DESCRIPTION
mem-fs@2.3.0 allows to filter files before adding to stream.
This PR adds filter that matches the first in-stream filter.