### PR TITLE
isbinaryfile does not follow semver for supported node, use fixed version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "deep-extend": "^0.6.0",
         "ejs": "^3.1.9",
         "globby": "^13.2.2",
-        "isbinaryfile": "^5.0.2",
+        "isbinaryfile": "5.0.2",
         "minimatch": "^9.0.3",
         "multimatch": "^6.0.0",
         "normalize-path": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "deep-extend": "^0.6.0",
     "ejs": "^3.1.9",
     "globby": "^13.2.2",
-    "isbinaryfile": "^5.0.0",
+    "isbinaryfile": "5.0.2",
     "minimatch": "^9.0.3",
     "multimatch": "^6.0.0",
     "normalize-path": "^3.0.0",


### PR DESCRIPTION
Use fixed version to avoid conflicts in the future

node v14 and v16 support were dropped in a patch version.