### PR TITLE
chore: update isbinaryfile and accept newer versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,15 @@
         "deep-extend": "^0.6.0",
         "ejs": "^3.1.10",
         "globby": "^14.0.2",
-        "isbinaryfile": "5.0.2",
+        "isbinaryfile": "5.0.3",
         "minimatch": "^9.0.3",
         "multimatch": "^7.0.0",
         "normalize-path": "^3.0.0",
         "textextensions": "^6.11.0",
         "vinyl": "^3.0.0"
+      },
+      "acceptDependencies": {
+        "isbinaryfile": "^5.0.3"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^7.18.0",
@@ -3078,9 +3081,9 @@
       "peer": true
     },
     "node_modules/isbinaryfile": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.2.tgz",
-      "integrity": "sha512-GvcjojwonMjWbTkfMpnVHVqXW/wKMYDfEpY94/8zy8HFMOqb/VL6oeONq9v87q4ttVlaTLnGXnJD4B5B1OTGIg==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.3.tgz",
+      "integrity": "sha512-VR4gNjFaDP8csJQvzInG20JvBj8MaHYLxNOMXysxRbGM7tcsHZwCjhch3FubFtZBkuDbN55i4dUukGeIrzF+6g==",
       "license": "MIT",
       "engines": {
         "node": ">= 18.0.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "deep-extend": "^0.6.0",
     "ejs": "^3.1.10",
     "globby": "^14.0.2",
-    "isbinaryfile": "5.0.2",
+    "isbinaryfile": "5.0.3",
     "minimatch": "^9.0.3",
     "multimatch": "^7.0.0",
     "normalize-path": "^3.0.0",
@@ -49,6 +49,9 @@
   },
   "peerDependencies": {
     "mem-fs": "^4.0.0"
+  },
+  "acceptDependencies": {
+    "isbinaryfile": "^5.0.3"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.18.0",


### PR DESCRIPTION
isbinaryfile does not respect node for major versions.
- bump isbinaryfile.
- accept newer isbinaryfile if other package already uses it to avoid duplications in node_modules.