### PR TITLE
chore: drop backward mem-fs compatibility

### DIFF
--- a/__tests__/copy-async.spec.ts
+++ b/__tests__/copy-async.spec.ts
@@ -45,16 +45,6 @@ describe('#copyAsync()', () => {
       expect(memFs.append).toHaveBeenCalledTimes(1);
       expect(memFs.read(newPath)).toBe(initialContents + initialContents);
     });
-
-    it('should throw if mem-fs is not compatible', async () => {
-      // @ts-expect-error - This is a legacy API
-      memFs.store.existsInMemory = undefined;
-      const filepath = getFixture('file-a.txt');
-      const newPath = '/new/path/file.txt';
-      await expect(memFs.copyAsync(filepath, newPath, { append: true, processFile: () => '' })).rejects.toEqual(
-        new Error('Current mem-fs is not compatible with append'),
-      );
-    });
   });
 
   it('can copy directory not commited to disk', async () => {

--- a/__tests__/copy.spec.ts
+++ b/__tests__/copy.spec.ts
@@ -55,16 +55,6 @@ describe('#copy()', () => {
       expect(memFs.append).toHaveBeenCalledTimes(1);
       expect(memFs.read(newPath)).toBe(initialContents + initialContents);
     });
-
-    it('should throw if mem-fs is not compatible', () => {
-      // @ts-expect-error - This is a legacy API
-      memFs.store.existsInMemory = undefined;
-      const filepath = getFixture('file-a.txt');
-      const newPath = '/new/path/file.txt';
-      expect(() => {
-        memFs.copy(filepath, newPath, { append: true });
-      }).toThrow();
-    });
   });
 
   it('can copy directory not commited to disk', () => {

--- a/src/actions/copy-async.ts
+++ b/src/actions/copy-async.ts
@@ -62,8 +62,7 @@ export async function copyAsync(
   to = path.resolve(to);
   if (typeof from === 'string') {
     // If `from` is a string and an existing file just go ahead and copy it.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (this.store.existsInMemory?.(from) && this.exists(from)) {
+    if (this.store.existsInMemory(from) && this.exists(from)) {
       this._copySingle(from, renderFilepath(to, context, tplSettings), options);
       return;
     }
@@ -88,8 +87,7 @@ export async function copyAsync(
 
   for (const resolvedFromPath of resolvedFromPaths) {
     const { resolvedFrom } = resolvedFromPath;
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (this.store.existsInMemory?.(resolvedFrom)) {
+    if (this.store.existsInMemory(resolvedFrom)) {
       storeFiles.push(resolvedFrom);
     } else {
       globResolved.push(resolvedFromPath);
@@ -170,12 +168,6 @@ export async function _copySingleAsync(
   const contents = await applyProcessingFileFunc.call(this, options.processFile, from);
 
   if (options.append) {
-    // Safety check against legacy API
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (!this.store.existsInMemory) {
-      throw new Error('Current mem-fs is not compatible with append');
-    }
-
     if (this.store.existsInMemory(to)) {
       this.append(to, contents, { create: true, ...options });
       return;


### PR DESCRIPTION
`existsInMemory` was added during mem-fs v2 cycle, mem-fs-editor has a peer-dependency on v4.