### PR TITLE
chore: types adjusts

### DIFF
--- a/__tests__/append-tpl.spec.ts
+++ b/__tests__/append-tpl.spec.ts
@@ -13,9 +13,9 @@ describe('#appendTpl()', () => {
 
   it('appends to file and processes contents as underscore template', () => {
     const filepath = getFixture('file-a.txt');
-    const originalContent = memFs.read(filepath)!.toString();
+    const originalContent = memFs.read(filepath).toString();
     const contentPath = getFixture('file-tpl.txt');
-    const contents = memFs.read(contentPath)!;
+    const contents = memFs.read(contentPath);
     memFs.appendTpl(filepath, contents, {
       name: 'bar',
     });
@@ -24,9 +24,9 @@ describe('#appendTpl()', () => {
 
   it('allows setting custom template delimiters', () => {
     const filepath = getFixture('file-a.txt');
-    const originalContent = memFs.read(filepath)!.toString();
+    const originalContent = memFs.read(filepath).toString();
     const contentPath = getFixture('file-tpl-custom-delimiter.txt');
-    const contents = memFs.read(contentPath)!;
+    const contents = memFs.read(contentPath);
     memFs.appendTpl(filepath, contents, { name: 'bar' }, { delimiter: '?' });
     expect(memFs.read(filepath)).toBe(originalContent + 'bar' + os.EOL);
   });
@@ -35,7 +35,7 @@ describe('#appendTpl()', () => {
     const f = () => {
       const filepath = getFixture('file-a.txt');
       const contentPath = getFixture('file-tpl.txt');
-      const contents = memFs.read(contentPath)!;
+      const contents = memFs.read(contentPath);
       memFs.appendTpl(filepath, contents);
     };
 

--- a/__tests__/copy-async.spec.ts
+++ b/__tests__/copy-async.spec.ts
@@ -30,7 +30,7 @@ describe('#copyAsync()', () => {
 
     it('should append file to file already loaded', async () => {
       const filepath = getFixture('file-a.txt');
-      const initialContents = memFs.read(filepath) ?? '';
+      const initialContents = memFs.read(filepath);
       const newPath = '/new/path/file.txt';
       await memFs.copyAsync(filepath, newPath, { append: true });
 

--- a/__tests__/copy.spec.ts
+++ b/__tests__/copy.spec.ts
@@ -40,7 +40,7 @@ describe('#copy()', () => {
 
     it('should append file to file already loaded', () => {
       const filepath = getFixture('file-a.txt');
-      const initialContents = memFs.read(filepath) ?? '';
+      const initialContents = memFs.read(filepath);
       const newPath = '/new/path/file.txt';
       memFs.copy(filepath, newPath, { append: true });
 

--- a/__tests__/read.spec.ts
+++ b/__tests__/read.spec.ts
@@ -19,7 +19,7 @@ describe('#read()', () => {
   });
 
   it('get the buffer content of a file', () => {
-    const content = memFs.read(fileA, { raw: true })!;
+    const content = memFs.read(fileA, { raw: true });
     expect(content).toBeInstanceOf(Buffer);
     expect(content.toString()).toBe('foo' + os.EOL);
   });
@@ -49,7 +49,7 @@ describe('#read()', () => {
     const content = memFs.read('file-who-does-not-exist.txt', {
       defaults: Buffer.from('foo' + os.EOL),
       raw: true,
-    })!;
+    });
     expect(content).toBeInstanceOf(Buffer);
     expect(content.toString()).toBe('foo' + os.EOL);
   });

--- a/src/actions/append.ts
+++ b/src/actions/append.ts
@@ -16,10 +16,6 @@ export default function append(this: MemFsEditor, to: string, contents: string |
   }
 
   let currentContents = this.read(to);
-  if (!currentContents) {
-    throw new Error(`Error appending to ${to}, file is empty.`);
-  }
-
   if (currentContents && opts.trimEnd) {
     currentContents = currentContents.replace(/\s+$/, '');
   }

--- a/src/actions/copy-tpl.ts
+++ b/src/actions/copy-tpl.ts
@@ -11,7 +11,7 @@ export function _processTpl(
     context,
     tplSettings,
   }: {
-    contents: string | Buffer;
+    contents: Buffer;
     filename: string;
     destination?: string;
     context?: Data;

--- a/src/actions/copy.ts
+++ b/src/actions/copy.ts
@@ -14,8 +14,8 @@ import { resolveFromPaths, render, getCommonPath, ResolvedFrom, globify, resolve
 const debug = createDebug('mem-fs-editor:copy');
 
 function applyProcessingFunc(
-  process: (contents: string | Buffer, filepath: string, destination: string) => string | Buffer,
-  contents: string | Buffer,
+  process: (contents: Buffer, filepath: string, destination: string) => string | Buffer,
+  contents: Buffer,
   filename: string,
   destination: string,
 ) {
@@ -121,7 +121,7 @@ export function copy(
 
 export type CopySingleOptions = {
   append?: boolean;
-  process?: (contents: string | Buffer, filepath: string, destination: string) => string | Buffer;
+  process?: (contents: Buffer, filepath: string, destination: string) => string | Buffer;
 };
 
 export function _copySingle(this: MemFsEditor, from: string, to: string, options: CopySingleOptions = {}) {

--- a/src/actions/read-json.ts
+++ b/src/actions/read-json.ts
@@ -6,10 +6,6 @@ export default function readJSON(this: MemFsEditor, filepath: string, defaults?:
   if (this.exists(filepath)) {
     try {
       const content = this.read(filepath);
-      if (!content) {
-        throw new Error(`${filepath} has no content`);
-      }
-
       return JSON.parse(content) as object;
     } catch (error) {
       throw new Error('Could not parse JSON in file: ' + filepath + '. Detail: ' + (error as Error).message);

--- a/src/actions/read.ts
+++ b/src/actions/read.ts
@@ -1,15 +1,15 @@
 import type { MemFsEditor } from '../index.js';
 
-function read(
+function read<const DefaultType extends string | null = string>(
   this: MemFsEditor,
   filepath: string,
-  options?: { raw?: boolean; defaults?: string | null },
-): string | null;
-function read(
+  options?: { raw?: boolean; defaults?: DefaultType },
+): string | DefaultType;
+function read<const DefaultType extends Buffer | null = Buffer>(
   this: MemFsEditor,
   filepath: string,
-  options: { raw?: true; defaults?: Buffer | null },
-): Buffer | string | null;
+  options: { raw?: true; defaults?: DefaultType },
+): Buffer | string | DefaultType;
 function read(
   this: MemFsEditor,
   filepath: string,
@@ -26,7 +26,7 @@ function read(
     throw new Error(filepath + " doesn't exist");
   }
 
-  return options.raw ? file.contents : file.contents.toString() || null;
+  return options.raw ? file.contents : file.contents.toString();
 }
 
 export default read;


### PR DESCRIPTION
`read()` never returns null.