### PR TITLE
Fix: Type inference of read method

### DIFF
--- a/__tests__/read.spec.ts
+++ b/__tests__/read.spec.ts
@@ -1,4 +1,4 @@
-import { describe, beforeEach, it, expect } from 'vitest';
+import { describe, beforeEach, it, expect, expectTypeOf } from 'vitest';
 import os from 'os';
 import { type MemFsEditor, MemFsEditorFile, create } from '../src/index.js';
 import { create as createMemFs } from 'mem-fs';
@@ -15,33 +15,41 @@ describe('#read()', () => {
 
   it('read the content of a file', () => {
     const content = memFs.read(fileA);
+    expectTypeOf(content).toEqualTypeOf<string>();
     expect(content).toBe('foo' + os.EOL);
   });
 
   it('get the buffer content of a file', () => {
     const content = memFs.read(fileA, { raw: true });
+    expectTypeOf(content).toEqualTypeOf<Buffer>();
     expect(content).toBeInstanceOf(Buffer);
     expect(content.toString()).toBe('foo' + os.EOL);
   });
 
   it('throws if file does not exist', () => {
-    expect(memFs.read.bind(memFs, 'file-who-does-not-exist.txt')).toThrow();
+    expect(() => {
+      memFs.read('file-who-does-not-exist.txt');
+    }).toThrow();
   });
 
   it('throws if file is deleted', () => {
     memFs.delete(fileA);
-    expect(memFs.read.bind(memFs, 'file-who-does-not-exist.txt')).toThrow();
+    expect(() => {
+      memFs.read('file-who-does-not-exist.txt');
+    }).toThrow();
   });
 
   it('returns defaults as String if file does not exist and defaults is provided', () => {
     const content = memFs.read('file-who-does-not-exist.txt', {
       defaults: 'foo' + os.EOL,
     });
+    expectTypeOf(content).toEqualTypeOf<string>();
     expect(content).toBe('foo' + os.EOL);
   });
 
   it('returns defaults as String if file does not exist and defaults is provided as empty string', () => {
     const content = memFs.read('file-who-does-not-exist.txt', { defaults: '' });
+    expectTypeOf(content).toEqualTypeOf<string>();
     expect(content).toBe('');
   });
 
@@ -50,6 +58,7 @@ describe('#read()', () => {
       defaults: Buffer.from('foo' + os.EOL),
       raw: true,
     });
+    expectTypeOf(content).toEqualTypeOf<Buffer | Buffer<ArrayBuffer>>();
     expect(content).toBeInstanceOf(Buffer);
     expect(content.toString()).toBe('foo' + os.EOL);
   });
@@ -57,11 +66,13 @@ describe('#read()', () => {
   it('returns defaults if file is deleted', () => {
     memFs.delete(fileA);
     const content = memFs.read(fileA, { defaults: 'foo' });
+    expectTypeOf(content).toEqualTypeOf<string>();
     expect(content).toBe('foo');
   });
 
   it('allows defaults to be null', () => {
     const content = memFs.read('not-existing.file', { defaults: null });
+    expectTypeOf(content).toEqualTypeOf<string | null>();
     expect(content).toBeNull();
   });
 });

--- a/src/actions/read.ts
+++ b/src/actions/read.ts
@@ -1,15 +1,17 @@
 import type { MemFsEditor } from '../index.js';
 
-function read<const DefaultType extends string | null = string>(
+function read(this: MemFsEditor, filepath: string, options?: never): string;
+function read<const DefaultType extends string | null>(
   this: MemFsEditor,
   filepath: string,
-  options?: { raw?: boolean; defaults?: DefaultType },
+  options: { raw?: false; defaults: DefaultType },
 ): string | DefaultType;
-function read<const DefaultType extends Buffer | null = Buffer>(
+function read(this: MemFsEditor, filepath: string, options: { raw: true; defaults?: never }): Buffer;
+function read<const DefaultType extends Buffer | null>(
   this: MemFsEditor,
   filepath: string,
-  options: { raw?: true; defaults?: DefaultType },
-): Buffer | string | DefaultType;
+  options: { raw: true; defaults: DefaultType },
+): Buffer | DefaultType;
 function read(
   this: MemFsEditor,
   filepath: string,


### PR DESCRIPTION
I don't think #310 worked as expected. It did fix cases where `null` cannot be returned, but the content type didn't work.

I add type tests in vitest to validate and enforce the right behavior is maintained in the future.

I'd appreciate if you can double-check and make sure this change does make sense @mshima! Thanks!