### PR TITLE
chore: reduce copy parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Append the new contents to the current file contents.
 - `options.separator` (default `os.EOL`). Separator to insert between current and new contents.
 - `options.create` (default `false`). Create the file if doesn't exists.
 
-### `#appendTpl(filepath, contents, context[, templateOptions[, [options]])`
+### `#appendTpl(filepath, contents, templateData[, templateOptions[, [options]])`
 
-Append the new `contents` to the exsting `filepath` content and parse the new contents as an [ejs](http://ejs.co/) template where `context` is the template context (the variable names available inside the template).
+Append the new `contents` to the exsting `filepath` content and parse the new contents as an [ejs](http://ejs.co/) template where `templateData` is the template data (the variable names available inside the template).
 
 - `options.trimEnd` (default `true`). Trim trailing whitespace of the current file contents.
 - `options.separator` (default `os.EOL`). Separator to insert between current and new contents.
@@ -73,7 +73,7 @@ Delete a file or a directory.
 
 `filePath` can also be a `glob`. If `filePath` is glob, you can optionally pass in an `options.globOptions` object to change its pattern matching behavior. The full list of options are being described [here](https://github.com/mrmlnc/fast-glob#options-1). The `sync` flag is forced to be `true` in `globOptions`.
 
-### `#copy(from, to, [options], context[, templateOptions ])`
+### `#copy(from, to, [options], templateData[, templateOptions ])`
 
 Copy file(s) from the `from` path to the `to` path.
 When passing array, you should pass `options.fromBasePath` to be used to calculate the `to` relative path. The common directory will be detected and used as `fromBasePath` otherwise.
@@ -89,22 +89,22 @@ Optionally, when `from` is a glob pattern, pass an `options.processDestinationPa
 
 `options.noGlob` can be used to by bypass glob matching entirely. In that case, `from` will directly match file paths against the file system.
 
-### `#copyAsync(from, to, [options], context[, templateOptions ])`
+### `#copyAsync(from, to, [options], templateData[, templateOptions ])`
 
 Async version of `copy`.
 
 `copy` loads `from` to memory and copy its contents to `to`.
 `copyAsync` copies directly from the disk to `to`, falling back to `copy` behavior if the file doesn't exists on disk.
 
-Same parameters of `copy` (see [copy() documentation for more details](#copyfrom-to-options-context-templateoptions-)).
+Same parameters of `copy` (see [copy() documentation for more details](#copyfrom-to-options-templatedata-templateoptions-)).
 
-### `#copyTpl(from, to, context[, templateOptions [, copyOptions]])`
+### `#copyTpl(from, to, templateData[, templateOptions [, copyOptions]])`
 
-Copy the `from` file and, if it is not a binary file, parse its content as an [ejs](http://ejs.co/) template where `context` is the template context (the variable names available inside the template).
+Copy the `from` file and, if it is not a binary file, parse its content as an [ejs](http://ejs.co/) template where `templateData` is the template data (the variable names available inside the template).
 
 You can optionally pass a `templateOptions` object. `mem-fs-editor` automatically setup the filename option so you can easily use partials.
 
-You can also optionally pass a `copyOptions` object (see [copy() documentation for more details](#copyfrom-to-options-context-templateoptions-)).
+You can also optionally pass a `copyOptions` object (see [copy() documentation for more details](#copyfrom-to-options-templatedata-templateoptions-)).
 
 Templates syntax looks like this:
 
@@ -121,13 +121,13 @@ Dir syntax looks like this:
 
 Refer to the [ejs documentation](http://ejs.co/) for more details.
 
-### `#copyTplAsync(from, to, [options], context[, templateOptions ])`
+### `#copyTplAsync(from, to, [options], templateData[, templateOptions ])`
 
 Async version of `copyTpl` that uses `copyAsync` instead of `copy`.
 
 Can be used for best performance. Reduces overheads.
 
-Same parameters of `copyTpl` (see [copyTpl() documentation for more details](#copyfrom-to-options-context-templateoptions-)).
+Same parameters of `copyTpl` (see [copyTpl() documentation for more details](#copyfrom-to-options-templatedata-templateoptions-)).
 
 ### `#move(from, to, [options])`
 

--- a/__tests__/commit.spec.ts
+++ b/__tests__/commit.spec.ts
@@ -196,7 +196,7 @@ describe('#copyTpl() and #commit()', () => {
     const b = { a };
     a.b = b;
 
-    memFs.copyTpl(getFixture('**'), output, { name: 'bar' }, { context: { a } });
+    memFs.copyTpl(getFixture('**'), output, { name: 'bar' }, { templateOptions: { context: { a } } });
   });
 
   afterEach(() => {

--- a/__tests__/copy-async.spec.ts
+++ b/__tests__/copy-async.spec.ts
@@ -114,7 +114,7 @@ describe('#copyAsync()', () => {
 
   it('accepts template paths', async () => {
     const outputFile = getFixture('test/<%= category %>/file-a.txt');
-    await memFs.copyAsync(getFixture('file-a.txt'), outputFile, {}, { category: 'foo' });
+    await memFs.copyAsync(getFixture('file-a.txt'), outputFile, { templateData: { category: 'foo' } });
     expect(memFs.read(getFixture('test/foo/file-a.txt'))).toBe('foo' + os.EOL);
   });
 

--- a/__tests__/copy-tpl-async.spec.ts
+++ b/__tests__/copy-tpl-async.spec.ts
@@ -56,7 +56,7 @@ describe('#copyTplAsync()', () => {
       newPath,
       { name: 'mustache' },
       {
-        delimiter: '?',
+        templateOptions: { delimiter: '?' },
       },
     );
     expect(memFs.read(newPath)).toBe('mustache' + os.EOL);
@@ -74,37 +74,42 @@ describe('#copyTplAsync()', () => {
     const newPath = '/new/path/file-append.txt';
     await memFs.copyTplAsync(filepath, newPath, { name: 'new content' });
     expect(memFs.read(newPath)).toBe('new content' + os.EOL);
-    await memFs.copyTplAsync(filepath, newPath, { name: 'new content' }, undefined, {
-      append: true,
-    });
+    await memFs.copyTplAsync(
+      filepath,
+      newPath,
+      { name: 'new content' },
+      {
+        append: true,
+      },
+    );
     expect(memFs.read(newPath)).toBe('new content' + os.EOL + 'new content' + os.EOL);
   });
 
   it('should pass globOptions to glob', async () => {
     const globOptions = { debug: false } as const;
     const filepath = getFixture('file-tpl-partial.*');
-    await memFs.copyTplAsync([filepath], '/new/path/', {}, {}, { globOptions, fromBasePath: getFixture() });
+    await memFs.copyTplAsync([filepath], '/new/path/', {}, { globOptions, fromBasePath: getFixture() });
 
     expect(glob).toHaveBeenCalledWith([normalizePath(filepath)], expect.objectContaining(globOptions));
   });
 
   it('should fail when passing noGlob and globOptions', async () => {
     await expect(
-      memFs.copyTplAsync(['foo'], '/new/path/', {}, {}, { globOptions: { debug: false }, noGlob: true }),
+      memFs.copyTplAsync(['foo'], '/new/path/', {}, { globOptions: { debug: false }, noGlob: true }),
     ).rejects.toThrowError('`noGlob` and `globOptions` are mutually exclusive');
   });
 
   it('should pass storeMatchOptions to multimatch', async () => {
     const storeMatchOptions = { debug: false } as const;
     const filepath = getFixture('file-tpl-partial.*');
-    await memFs.copyTplAsync([filepath], '/new/path/', {}, {}, { storeMatchOptions, fromBasePath: getFixture() });
+    await memFs.copyTplAsync([filepath], '/new/path/', {}, { storeMatchOptions, fromBasePath: getFixture() });
 
     expect(multimatch).toHaveBeenCalledWith(expect.any(Array), [normalizePath(filepath)], storeMatchOptions);
   });
 
   it('should fail when passing noGlob and storeMatchOptions', async () => {
     await expect(
-      memFs.copyTplAsync(['foo'], '/new/path/', {}, {}, { storeMatchOptions: { debug: false }, noGlob: true }),
+      memFs.copyTplAsync(['foo'], '/new/path/', {}, { storeMatchOptions: { debug: false }, noGlob: true }),
     ).rejects.toThrowError('`noGlob` and `storeMatchOptions` are mutually exclusive');
   });
 
@@ -126,7 +131,7 @@ describe('#copyTplAsync()', () => {
       newPath,
       {},
       {
-        context: { a },
+        templateOptions: { context: { a } },
       },
     );
     expect(memFs.read(newPath)).toBe('new content new content' + os.EOL);

--- a/__tests__/copy-tpl.spec.ts
+++ b/__tests__/copy-tpl.spec.ts
@@ -40,7 +40,7 @@ describe('#copyTpl()', () => {
       newPath,
       { name: 'mustache' },
       {
-        delimiter: '?',
+        templateOptions: { delimiter: '?' },
       },
     );
     expect(memFs.read(newPath)).toBe('mustache' + os.EOL);
@@ -58,37 +58,42 @@ describe('#copyTpl()', () => {
     const newPath = '/new/path/file-append.txt';
     memFs.copyTpl(filepath, newPath, { name: 'new content' });
     expect(memFs.read(newPath)).toBe('new content' + os.EOL);
-    memFs.copyTpl(filepath, newPath, { name: 'new content' }, undefined, {
-      append: true,
-    });
+    memFs.copyTpl(
+      filepath,
+      newPath,
+      { name: 'new content' },
+      {
+        append: true,
+      },
+    );
     expect(memFs.read(newPath)).toBe('new content' + os.EOL + 'new content' + os.EOL);
   });
 
   it('should pass globOptions to glob', () => {
     const globOptions = { debug: false } as const;
     const filepath = getFixture('file-tpl-partial.*');
-    memFs.copyTpl([filepath], '/new/path/', {}, {}, { globOptions, fromBasePath: getFixture() });
+    memFs.copyTpl([filepath], '/new/path/', {}, { globOptions, fromBasePath: getFixture() });
 
     expect(globSync).toHaveBeenCalledWith([normalize(filepath)], expect.objectContaining(globOptions));
   });
 
   it('should fail when passing noGlob and globOptions', () => {
     expect(() => {
-      memFs.copyTpl(['foo'], '/new/path/', {}, {}, { globOptions: { debug: false }, noGlob: true });
+      memFs.copyTpl(['foo'], '/new/path/', {}, { globOptions: { debug: false }, noGlob: true });
     }).toThrowError('`noGlob` and `globOptions` are mutually exclusive');
   });
 
   it('should pass storeMatchOptions to multimatch', () => {
     const storeMatchOptions = { debug: false } as const;
     const filepath = getFixture('file-tpl-partial.*');
-    memFs.copyTpl([filepath], '/new/path/', {}, {}, { storeMatchOptions, fromBasePath: getFixture() });
+    memFs.copyTpl([filepath], '/new/path/', {}, { storeMatchOptions, fromBasePath: getFixture() });
 
     expect(multimatch).toHaveBeenCalledWith(expect.any(Array), [normalize(filepath)], storeMatchOptions);
   });
 
   it('should fail when passing noGlob and storeMatchOptions', () => {
     expect(() => {
-      memFs.copyTpl(['foo'], '/new/path/', {}, {}, { storeMatchOptions: { debug: false }, noGlob: true });
+      memFs.copyTpl(['foo'], '/new/path/', {}, { storeMatchOptions: { debug: false }, noGlob: true });
     }).toThrowError('`noGlob` and `storeMatchOptions` are mutually exclusive');
   });
 
@@ -119,7 +124,7 @@ describe('#copyTpl()', () => {
       newPath,
       {},
       {
-        context: { a },
+        templateOptions: { context: { a } },
       },
     );
     expect(memFs.read(newPath)).toBe('new content new content' + os.EOL);

--- a/__tests__/copy.spec.ts
+++ b/__tests__/copy.spec.ts
@@ -137,7 +137,7 @@ describe('#copy()', () => {
 
   it('accepts template paths', () => {
     const outputFile = getFixture('test/<%= category %>/file-a.txt');
-    memFs.copy(getFixture('file-a.txt'), outputFile, {}, { category: 'foo' });
+    memFs.copy(getFixture('file-a.txt'), outputFile, { templateData: { category: 'foo' } });
     expect(memFs.read(getFixture('test/foo/file-a.txt'))).toBe('foo' + os.EOL);
   });
 

--- a/src/actions/append-tpl.ts
+++ b/src/actions/append-tpl.ts
@@ -7,9 +7,9 @@ export default function appendTpl(
   this: MemFsEditor,
   to: string,
   contents: string | Buffer,
-  context?: Data,
-  tplSettings?: Options,
+  templateData?: Data,
+  templateOptions?: Options,
   options?: AppendOptions,
 ) {
-  this.append(to, render(contents.toString(), context, tplSettings), options);
+  this.append(to, render(contents.toString(), templateData, templateOptions), options);
 }

--- a/src/actions/copy-tpl.ts
+++ b/src/actions/copy-tpl.ts
@@ -1,4 +1,4 @@
-import type { Data, Options } from 'ejs';
+import type { Data } from 'ejs';
 import type { MemFsEditor } from '../index.js';
 import type { CopyOptions } from './copy.js';
 import { processTpl } from '../util.js';
@@ -7,22 +7,14 @@ export function copyTpl(
   this: MemFsEditor,
   from: string | string[],
   to: string,
-  context?: Data,
-  tplSettings?: Options,
-  options?: CopyOptions,
+  templateData: Data = {},
+  options: Omit<CopyOptions, 'templateData'> = {},
 ) {
-  context ||= {};
-  tplSettings ||= {};
-
-  this.copy(
-    from,
-    to,
-    {
-      processDestinationPath: (path) => path.replace(/.ejs$/, ''),
-      ...options,
-      process: (contents, filename) => processTpl({ contents, filename, context, tplSettings }),
-    },
-    context,
-    tplSettings,
-  );
+  const { templateOptions } = options;
+  this.copy(from, to, {
+    processDestinationPath: (path) => path.replace(/.ejs$/, ''),
+    ...options,
+    process: (contents, filename) => processTpl({ contents, filename, templateData, templateOptions }),
+    templateData,
+  });
 }

--- a/src/actions/copy.ts
+++ b/src/actions/copy.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
 import createDebug from 'debug';
-import type { Data, Options } from 'ejs';
+import type { Data as EjsData, Options as EjsOptions } from 'ejs';
 import { globSync, isDynamicPattern, type GlobOptions } from 'tinyglobby';
 import multimatch from 'multimatch';
 import type { Options as MultimatchOptions } from 'multimatch';
@@ -42,16 +42,11 @@ export type CopyOptions = CopySingleOptions & {
   ignoreNoMatch?: boolean;
   fromBasePath?: string;
   processDestinationPath?: (filepath: string) => string;
+  templateData?: EjsData;
+  templateOptions?: EjsOptions;
 };
 
-export function copy(
-  this: MemFsEditor,
-  from: string | string[],
-  to: string,
-  options: CopyOptions = {},
-  context?: Data,
-  tplSettings?: Options,
-) {
+export function copy(this: MemFsEditor, from: string | string[], to: string, options: CopyOptions = {}) {
   const { fromBasePath = getCommonPath(from), noGlob } = options;
   const hasGlobOptions = Boolean(options.globOptions);
   const hasMultimatchOptions = Boolean(options.storeMatchOptions);
@@ -130,8 +125,8 @@ export function copy(
   const processDestinationPath = options.processDestinationPath || ((destPath) => destPath);
   foundFiles.forEach((file) => {
     let toFile = treatToAsDir ? processDestinationPath(path.join(to, file.relativeFrom)) : to;
-    if (context) {
-      toFile = render(toFile, context, { ...tplSettings, cache: false });
+    if (options.templateData) {
+      toFile = render(toFile, options.templateData, { ...options.templateOptions, cache: false });
     }
 
     copySingle(this, file.resolvedFrom, toFile, options);

--- a/src/util.ts
+++ b/src/util.ts
@@ -89,24 +89,24 @@ export function renderFile(template: string, data?: ejs.Data, options?: ejs.Opti
 export function processTpl({
   contents,
   filename,
-  context,
-  tplSettings,
+  templateData,
+  templateOptions,
 }: {
   contents: Buffer;
   filename: string;
   destination?: string;
-  context?: Data;
-  tplSettings?: Options;
+  templateData?: Data;
+  templateOptions?: Options;
 }): string | Buffer {
   if (isBinary(filename, contents)) {
     return contents;
   }
 
-  return render(contents.toString(), context, {
+  return render(contents.toString(), templateData, {
     // Setting filename by default allow including partials.
     filename,
     cache: true,
-    ...tplSettings,
+    ...templateOptions,
   });
 }
 


### PR DESCRIPTION
having templateData and templateSetting as options instead of direct parameters of copy is cleaner and makes more sense.